### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-duo/main.go
+++ b/cmd/baton-duo/main.go
@@ -47,7 +47,7 @@ func getConnector(ctx context.Context, duoCfg *cfg.Duo) (types.ConnectorServer, 
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, duoCfg.IntegrationKey, duoCfg.SecretKey, duoCfg.ApiHostname)
+	cb, err := connector.New(ctx, duoCfg.IntegrationKey, duoCfg.SecretKey, duoCfg.ApiHostname, duoCfg.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,9 +7,10 @@ type Duo struct {
 	IntegrationKey string `mapstructure:"integration-key"`
 	SecretKey string `mapstructure:"secret-key"`
 	ApiHostname string `mapstructure:"api-hostname"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
-func (c* Duo) findFieldByTag(tagValue string) (any, bool) {
+func (c *Duo) findFieldByTag(tagValue string) (any, bool) {
 	v := reflect.ValueOf(c).Elem() // Dereference pointer to struct
 	t := v.Type()
 
@@ -41,11 +42,13 @@ func (c *Duo) GetString(fieldName string) string {
 	if !ok {
 		return ""
 	}
-	t, ok := v.(string)
-	if !ok {
-		panic("wrong type")
+	if t, ok := v.(string); ok {
+		return t
 	}
-	return t
+	if t, ok := v.([]byte); ok {
+		return string(t)
+	}
+	panic("wrong type")
 }
 
 func (c *Duo) GetInt(fieldName string) int {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Duo API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Duo API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,10 +29,16 @@ var (
 		field.WithDescription("Duo api hostname key needed to complete the setup to connect to the Duo API."),
 	)
 
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Duo API URL (for testing)"),
+	)
+
 	ConfigurationFields = []field.SchemaField{
 		IntegrationKey,
 		SecretKey,
 		ApiHostname,
+		BaseURLField,
 	}
 )
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -83,14 +83,14 @@ func (d *Duo) Validate(ctx context.Context) (annotations.Annotations, error) {
 }
 
 // New returns the Duo connector.
-func New(ctx context.Context, integrationKey string, secretKey string, apiHostname string) (*Duo, error) {
+func New(ctx context.Context, integrationKey string, secretKey string, apiHostname string, baseURL string) (*Duo, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
 
 	return &Duo{
-		client:         duo.NewClient(integrationKey, secretKey, apiHostname, httpClient),
+		client:         duo.NewClient(integrationKey, secretKey, apiHostname, baseURL, httpClient),
 		integrationKey: integrationKey,
 	}, nil
 }

--- a/pkg/duo/client.go
+++ b/pkg/duo/client.go
@@ -35,14 +35,17 @@ type Client struct {
 
 func NewClient(integrationKey string, secretKey string, apiHostname string, baseURL string, httpClient *http.Client) *Client {
 	effectiveBaseURL := baseURL
+	effectiveHost := apiHostname
 	if effectiveBaseURL == "" {
 		effectiveBaseURL = fmt.Sprintf("https://%s", apiHostname)
+	} else if u, err := url.Parse(effectiveBaseURL); err == nil && u.Host != "" {
+		effectiveHost = u.Host
 	}
 	return &Client{
 		integrationKey: integrationKey,
 		secretKey:      secretKey,
 		baseUrl:        effectiveBaseURL,
-		host:           apiHostname,
+		host:           effectiveHost,
 		wrapper:        uhttp.NewBaseHttpClient(httpClient),
 	}
 }

--- a/pkg/duo/client.go
+++ b/pkg/duo/client.go
@@ -33,12 +33,15 @@ type Client struct {
 	host           string
 }
 
-func NewClient(integrationKey string, secretKey string, apiHostname string, httpClient *http.Client) *Client {
-	baseUrl := fmt.Sprintf("https://%s", apiHostname)
+func NewClient(integrationKey string, secretKey string, apiHostname string, baseURL string, httpClient *http.Client) *Client {
+	effectiveBaseURL := baseURL
+	if effectiveBaseURL == "" {
+		effectiveBaseURL = fmt.Sprintf("https://%s", apiHostname)
+	}
 	return &Client{
 		integrationKey: integrationKey,
 		secretKey:      secretKey,
-		baseUrl:        baseUrl,
+		baseUrl:        effectiveBaseURL,
 		host:           apiHostname,
 		wrapper:        uhttp.NewBaseHttpClient(httpClient),
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-duo/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/duo/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-duo --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to override the Duo API URL (hidden/for testing), allowing the connector to target alternate API endpoints.
  * When unset, the connector still derives a default HTTPS API URL from the configured API hostname.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->