### PR TITLE
cxp-440 use api instead of hardcoded list for roles

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -4,15 +4,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
-
-func titleCase(s string) string {
-	titleCaser := cases.Title(language.English)
-
-	return titleCaser.String(s)
-}
 
 func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, error) {
 	b := &pagination.Bag{}

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -22,46 +22,44 @@ func (o *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 	return o.resourceType
 }
 
-const (
-	owner              = "owner"
-	administrator      = "administrator"
-	applicationManager = "application manager"
-	userManager        = "user manager"
-	helpDesk           = "help desk"
-	billing            = "billing"
-	phishingManager    = "phishing manager"
-	readOnly           = "readonly"
-)
-
-var roles = []string{
-	owner,
-	administrator,
-	applicationManager,
-	userManager,
-	helpDesk,
-	billing,
-	phishingManager,
-	readOnly,
+// legacyRoleID maps the API's role_id to the hardcoded ID previously used by
+// this resource type. These aliases let ConductorOne resolve existing
+// references after the migration from the old hardcoded list to API-sourced roles.
+var legacyRoleID = map[string]string{
+	"owner":               "owner",
+	"service_manager":     "administrator",
+	"application_manager": "application manager",
+	"user_manager":        "user manager",
+	"help_desk":           "help desk",
+	"billing":             "billing",
+	"read_only":           "read-only",
 }
 
 // Create a new connector resource for a Duo role.
-func roleResource(ctx context.Context, role string, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
-	roleDisplayName := titleCase(role)
+func roleResource(_ context.Context, role duo.Role, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"role_name": roleDisplayName,
-		"role_id":   role,
+		"role_name": role.Name,
+		"role_id":   role.RoleID,
+		"is_custom": role.IsCustom,
 	}
 
 	roleTraitOptions := []resource.RoleTraitOption{
 		resource.WithRoleProfile(profile),
 	}
 
-	ret, err := resource.NewRoleResource(
-		roleDisplayName,
-		resourceTypeRole,
-		role,
-		roleTraitOptions,
+	resourceOpts := []resource.ResourceOption{
 		resource.WithParentResourceID(parentResourceID),
+	}
+	if legacy, ok := legacyRoleID[role.RoleID]; ok {
+		resourceOpts = append(resourceOpts, resource.WithAliases(legacy))
+	}
+
+	ret, err := resource.NewRoleResource(
+		role.Name,
+		resourceTypeRole,
+		role.RoleID,
+		roleTraitOptions,
+		resourceOpts...,
 	)
 	if err != nil {
 		return nil, err
@@ -73,6 +71,11 @@ func roleResource(ctx context.Context, role string, parentResourceID *v2.Resourc
 func (o *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, token *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	if parentId == nil {
 		return nil, "", nil, nil
+	}
+
+	roles, err := o.client.GetRoles(ctx)
+	if err != nil {
+		return nil, "", nil, err
 	}
 
 	var rv []*v2.Resource
@@ -107,6 +110,7 @@ func (o *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, to
 	if err != nil {
 		return nil, "", nil, err
 	}
+
 	admins, offset, err := o.client.GetAdmins(ctx, bag.PageToken())
 	if err != nil {
 		return nil, "", nil, err
@@ -120,13 +124,12 @@ func (o *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, to
 
 	var rv []*v2.Grant
 	for _, admin := range admins {
-		if resource.DisplayName == admin.Role {
+		if resource.Id.Resource == admin.RoleID {
 			adminCopy := admin
 			ar, err := adminResource(ctx, &adminCopy, resource.Id)
 			if err != nil {
 				return nil, "", nil, err
 			}
-
 			permissionGrant := grant.NewGrant(resource, memberEntitlement, ar.Id)
 			rv = append(rv, permissionGrant)
 		}

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -73,7 +73,7 @@ func (o *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, to
 		return nil, "", nil, nil
 	}
 
-	roles, err := o.client.GetRoles(ctx)
+	roles, rl, err := o.client.GetRoles(ctx)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -87,7 +87,7 @@ func (o *roleResourceType) List(ctx context.Context, parentId *v2.ResourceId, to
 		rv = append(rv, rr)
 	}
 
-	return rv, "", nil, nil
+	return rv, "", annotations.New(rl), nil
 }
 
 func (o *roleResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
@@ -125,8 +125,7 @@ func (o *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, to
 	var rv []*v2.Grant
 	for _, admin := range admins {
 		if resource.Id.Resource == admin.RoleID {
-			adminCopy := admin
-			ar, err := adminResource(ctx, &adminCopy, resource.Id)
+			ar, err := adminResource(ctx, &admin, resource.Id)
 			if err != nil {
 				return nil, "", nil, err
 			}

--- a/pkg/duo/client.go
+++ b/pkg/duo/client.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -24,7 +26,7 @@ const (
 )
 
 type Client struct {
-	httpClient     *http.Client
+	wrapper        *uhttp.BaseHttpClient
 	integrationKey string
 	secretKey      string
 	baseUrl        string
@@ -38,7 +40,7 @@ func NewClient(integrationKey string, secretKey string, apiHostname string, http
 		secretKey:      secretKey,
 		baseUrl:        baseUrl,
 		host:           apiHostname,
-		httpClient:     httpClient,
+		wrapper:        uhttp.NewBaseHttpClient(httpClient),
 	}
 }
 
@@ -354,28 +356,29 @@ func (c *Client) GetAccount(ctx context.Context) (Account, error) {
 	return res.Response, nil
 }
 
-// GetRoles returns all admin roles.
-func (c *Client) GetRoles(ctx context.Context) ([]Role, error) {
+// GetRoles returns all admin roles along with rate limit data from the response headers.
+func (c *Client) GetRoles(ctx context.Context) ([]Role, *v2.RateLimitDescription, error) {
 	uri := "/admin/v1/admin_roles"
 	rolesUrl, err := url.JoinPath(c.baseUrl, uri)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rolesUrl, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var res RolesResponse
-	if err := c.doRequest(uri, req, &res, nil); err != nil {
-		return nil, err
+	rl, err := c.do(uri, req, &res, nil)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	if res.Stat == requestFailedStat {
-		return nil, wrapError(res.ErrorResponse, "error fetching roles")
+		return nil, rl, wrapError(res.ErrorResponse, "error fetching roles")
 	}
 
-	return res.Response, nil
+	return res.Response, rl, nil
 }
 
 // AddUserToGroup adds a user to a group.
@@ -431,27 +434,37 @@ func (c *Client) RemoveUserFromGroup(ctx context.Context, groupId, userId string
 	return nil
 }
 
-func (c *Client) doRequest(uri string, req *http.Request, resType interface{}, params url.Values) error {
+// do executes the request, decodes the JSON response body into resType, and returns
+// any rate limit information parsed from the response headers.
+func (c *Client) do(uri string, req *http.Request, resType interface{}, params url.Values) (*v2.RateLimitDescription, error) {
 	now := time.Now().UTC().Format(time.RFC1123Z)
 	signature, err := sign(c.integrationKey, c.secretKey, req.Method, c.host, uri, now, params)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req.Header.Add("Authorization", signature)
 	req.Header.Add("Date", now)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
+	var rl v2.RateLimitDescription
 	// #nosec G704 -- URL is config baseUrl + fixed path pattern, not user-controlled
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.wrapper.Do(req,
+		uhttp.WithJSONResponse(resType),
+		uhttp.WithRatelimitData(&rl),
+	)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if err := json.NewDecoder(resp.Body).Decode(&resType); err != nil {
-		return err
+		return &rl, err
 	}
 
-	return nil
+	return &rl, nil
+}
+
+// doRequest executes the request and decodes the response, discarding rate limit data.
+func (c *Client) doRequest(uri string, req *http.Request, resType interface{}, params url.Values) error {
+	_, err := c.do(uri, req, resType, params)
+	return err
 }

--- a/pkg/duo/client.go
+++ b/pkg/duo/client.go
@@ -94,6 +94,11 @@ type AccountResponse struct {
 	Response Account `json:"response"`
 }
 
+type RolesResponse struct {
+	ErrorResponse
+	Stat     string `json:"stat"`
+	Response []Role `json:"response"`
+}
 
 func duoToGRPCErrorCode(duoCode int64) codes.Code {
 	// Extract the first 3 digits from the left, Duo sends a 5 digit code for errors
@@ -328,7 +333,6 @@ func (c *Client) GetUser(ctx context.Context, userId string) (User, error) {
 	return res.Response, nil
 }
 
-
 // GetAccount returns account info.
 func (c *Client) GetAccount(ctx context.Context) (Account, error) {
 	uri := "/admin/v1/settings"
@@ -345,6 +349,30 @@ func (c *Client) GetAccount(ctx context.Context) (Account, error) {
 
 	if res.Stat == requestFailedStat {
 		return Account{}, wrapError(res.ErrorResponse, "error fetching account")
+	}
+
+	return res.Response, nil
+}
+
+// GetRoles returns all admin roles.
+func (c *Client) GetRoles(ctx context.Context) ([]Role, error) {
+	uri := "/admin/v1/admin_roles"
+	rolesUrl, err := url.JoinPath(c.baseUrl, uri)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rolesUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res RolesResponse
+	if err := c.doRequest(uri, req, &res, nil); err != nil {
+		return nil, err
+	}
+
+	if res.Stat == requestFailedStat {
+		return nil, wrapError(res.ErrorResponse, "error fetching roles")
 	}
 
 	return res.Response, nil

--- a/pkg/duo/models.go
+++ b/pkg/duo/models.go
@@ -25,9 +25,18 @@ type Admin struct {
 	Email   string `json:"email"`
 	Name    string `json:"name"`
 	Role    string `json:"role"`
+	RoleID  string `json:"role_id"`
 	Status  string `json:"status"`
 }
 
 type Account struct {
 	Name string `json:"name"`
+}
+
+type Role struct {
+	RoleID      string `json:"role_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InUse       bool   `json:"in_use"`
+	IsCustom    bool   `json:"is_custom"`
 }


### PR DESCRIPTION
Replaced hardcoded role list with API call to avoid missing or non existing roles. This endpoint also list custom roles (feature [currently in beta](https://duo.com/docs/admin-roles#:~:text=users%20or%20applications.-,Custom%20Admin%20Role,-%3A%20If%20you%20have) in DUO)

Uses withAliases for retro compatibility since we are now using the roleId as ID. 
NOTE: This is also a useful change since admin.role field (which we were using to generate grants) is a legacy field and [will be deprecated](https://duo.com/docs/adminapi#administrators:~:text=This%20legacy%20property%20will%20be%20deprecated%20in%20the%20future%2C%20with%20role_id%20as%20the%20replacement.) 