### PR TITLE
cxp-440 backwards compatibility for roles

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -50,14 +50,16 @@ func roleResource(_ context.Context, role duo.Role, parentResourceID *v2.Resourc
 	resourceOpts := []resource.ResourceOption{
 		resource.WithParentResourceID(parentResourceID),
 	}
+	legacyCompatibleResourceID := role.RoleID
 	if legacy, ok := legacyRoleID[role.RoleID]; ok {
-		resourceOpts = append(resourceOpts, resource.WithAliases(legacy))
+		// TODO: Use withAliases to migrate to proper IDs once the feature is fully supported.
+		legacyCompatibleResourceID = legacy
 	}
 
 	ret, err := resource.NewRoleResource(
 		role.Name,
 		resourceTypeRole,
-		role.RoleID,
+		legacyCompatibleResourceID,
 		roleTraitOptions,
 		resourceOpts...,
 	)

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -126,7 +126,12 @@ func (o *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, to
 
 	var rv []*v2.Grant
 	for _, admin := range admins {
-		if resource.Id.Resource == admin.RoleID {
+		legacyCompatibleAdminID := admin.RoleID
+		if legacy, ok := legacyRoleID[admin.RoleID]; ok {
+			// TODO: Use withAliases to migrate to proper IDs once the feature is fully supported.
+			legacyCompatibleAdminID = legacy
+		}
+		if resource.Id.Resource == legacyCompatibleAdminID {
 			ar, err := adminResource(ctx, &admin, resource.Id)
 			if err != nil {
 				return nil, "", nil, err


### PR DESCRIPTION
Only new grants discovered for readonly, a custom role and security analyst. No previous grants dropped. 

<img width="953" height="871" alt="image" src="https://github.com/user-attachments/assets/944de086-9165-4b19-9a09-848485d8e735" />

