### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Set up a Duo connector"
-og:title: "Set up a Duo connector"
+title:"Set up a Cisco Duo connector"
+og:title:"Set up a Cisco Duo connector"
 description: "C1 provides identity governance for Duo. Integrate your Duo instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 og:description: "C1 provides identity governance for Duo. Integrate your Duo instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Cisco Duo"
@@ -55,7 +55,7 @@ A user with the **Owner** role in Duo must perform this task.
   </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Duo connector
 
@@ -105,7 +105,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your Duo connector is now pulling access data into C1.
+**Done.** Your Duo connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -220,7 +220,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your Duo connector is now pulling access data into C1.
+**Done.** Your Duo connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,6 +1,6 @@
 ---
-title:"Set up a Cisco Duo connector"
-og:title:"Set up a Cisco Duo connector"
+title: "Set up a Cisco Duo connector"
+og:title: "Set up a Cisco Duo connector"
 description: "C1 provides identity governance for Duo. Integrate your Duo instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 og:description: "C1 provides identity governance for Duo. Integrate your Duo instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Cisco Duo"


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`